### PR TITLE
Fix bugs related to ENABLE_PROXY and Proxy URL handling

### DIFF
--- a/apiServer.js
+++ b/apiServer.js
@@ -11,6 +11,7 @@ const { resolveImdbId } = require('./utils/tmdb');
 const { applyFilters } = require('./utils/streamFilters');
 
 const app = express();
+app.set('trust proxy', 1);
 
 // Conditionally mount proxy routes early so downstream handlers can use them
 if (config.enableProxy) {

--- a/proxy/proxyServer.js
+++ b/proxy/proxyServer.js
@@ -95,7 +95,9 @@ function extractOriginalUrl(proxyUrl) {
                 while (decoded.includes('%2F')) {
                     try { decoded = decodeURIComponent(decoded); } catch { break; }
                 }
-                return decoded;
+                if (decoded.startsWith('http://') || decoded.startsWith('https://')) return decoded;
+                // If it's just a path (like Vidlink /proxy/wiwii/...), keep the full original URL
+                return proxyUrl;
             }
         }
         if (url.searchParams.has('url')) return decodeURIComponent(url.searchParams.get('url'));

--- a/utils/config.js
+++ b/utils/config.js
@@ -173,7 +173,8 @@ function loadConfig() {
     showboxCacheDir: process.env.SHOWBOX_CACHE_DIR || null,
     // Proxy/env paths removed; always direct connections
     disableUrlValidation: process.env.DISABLE_URL_VALIDATION,
-    disable4khdhubUrlValidation: process.env.DISABLE_4KHDHUB_URL_VALIDATION
+    disable4khdhubUrlValidation: process.env.DISABLE_4KHDHUB_URL_VALIDATION,
+    enableProxy: process.env.ENABLE_PROXY
   };
   
   // Dynamic provider enable flags from env


### PR DESCRIPTION
This pull request introduces improvements to proxy handling and configuration management, and makes a minor Express app setting change. The main changes are grouped below:

**Proxy Handling Improvements:**

* Updated the `extractOriginalUrl` function in `proxy/proxyServer.js` to better handle proxy URLs: it now checks if the decoded value is a full URL and only returns it if so; otherwise, it returns the original `proxyUrl`, improving compatibility with path-based proxies.

**Configuration Management:**

* Added support for an `ENABLE_PROXY` environment variable in `utils/config.js`, allowing proxy functionality to be toggled via configuration.

**Express App Settings:**

* Set `'trust proxy'` to `1` in the Express app in `apiServer.js`, which is important for correct client IP handling when behind a proxy.